### PR TITLE
Firebase auth + App server REST Service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,11 +20,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support:support-v4:28.0.0-rc01'
-    implementation 'com.android.support:support-media-compat:28.0.0-rc01'
-    implementation 'com.android.support:animated-vector-drawable:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.firebase:firebase-messaging:17.3.0'
     implementation 'com.google.firebase:firebase-auth:16.0.3'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "ar.uba.fi.mercadolibre"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -28,8 +28,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:17.3.0'
     implementation 'com.google.firebase:firebase-auth:16.0.3'
 
-    implementation 'com.facebook.android:facebook-android-sdk:4.36.0'
-
+    implementation 'com.firebaseui:firebase-ui-auth:4.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,13 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.13'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.4.0'
+
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     implementation 'com.android.support:animated-vector-drawable:28.0.0-rc01'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.google.firebase:firebase-messaging:17.3.0'
+    implementation 'com.google.firebase:firebase-auth:16.0.3'
+
+    implementation 'com.facebook.android:facebook-android-sdk:4.36.0'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -23,6 +23,14 @@
           }
         },
         {
+          "client_id": "148642265280-9k37d5uem0ee2lktm2903irarene398o.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "ar.uba.fi.mercadolibre",
+            "certificate_hash": "4ffae6d7533c4e1cec23a8769d30598bebea60f2"
+          }
+        },
+        {
           "client_id": "148642265280-f5kon28jcm5n0ec6cnal48m8rv5skiic.apps.googleusercontent.com",
           "client_type": 3
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ar.uba.fi.mercadolibre">
+    <uses-permission android:name="android.permission.INTERNET" />
+
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
@@ -21,6 +21,9 @@ import ar.uba.fi.mercadolibre.server_api.AppServer;
 import io.reactivex.disposables.CompositeDisposable;
 
 public class MainActivity extends AppCompatActivity {
+    // No se como leer esto desde una env variable o lo que sea
+    static final String APP_SERVER_URL = "http://0.0.0.0:8000";
+
     protected CompositeDisposable compositeDisposable;
     private FirebaseAuth mAuth;
     private static final int RC_SIGN_IN = 123;
@@ -95,7 +98,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         // SAMPLE API CALL!
-        AppServer as = new AppServer("http://0.0.0.0:8000");
+        AppServer as = new AppServer(APP_SERVER_URL);
         as.api();
 
     }

--- a/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
@@ -3,11 +3,26 @@ package ar.uba.fi.mercadolibre;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+
 public class MainActivity extends AppCompatActivity {
+
+    private FirebaseAuth mAuth;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mAuth = FirebaseAuth.getInstance();
         setContentView(R.layout.activity_main);
+    }
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        FirebaseUser currentUser = mAuth.getCurrentUser();
+        if (currentUser != null) {
+            setContentView(R.layout.activity_signed_in);
+        }
     }
 }

--- a/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
@@ -45,26 +45,12 @@ public class MainActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         // Esto se ejecuta luego del (intento de) sign in del usuario
         super.onActivityResult(requestCode, resultCode, data);
-
         if (requestCode == RC_SIGN_IN) {
             // IdpResponse response = IdpResponse.fromResultIntent(data);
 
             if (resultCode == RESULT_OK) {
                 // Successfully signed in
-                FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
-                assert user != null;
-                user.getIdToken(true)
-                        .addOnCompleteListener(new OnCompleteListener<GetTokenResult>() {
-                            public void onComplete(@NonNull Task<GetTokenResult> task) {
-                                if (task.isSuccessful()) {
-                                    String idToken = task.getResult().getToken();
-                                    // Send token to your backend via HTTPS
-                                    // ...
-                                } else {
-                                    // Handle error -> task.getException();
-                                }
-                            }
-                        });                setContentView(R.layout.activity_signed_in);
+                processSuccessSignin();
 
             } else {
                 // Sign in failed. If response is null the user canceled the
@@ -75,6 +61,24 @@ public class MainActivity extends AppCompatActivity {
             }
         }
     }
+
+    private void processSuccessSignin() {
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        assert user != null;
+        user.getIdToken(true)
+            .addOnCompleteListener(new OnCompleteListener<GetTokenResult>() {
+                public void onComplete(@NonNull Task<GetTokenResult> task) {
+                if (task.isSuccessful()) {
+                    String idToken = task.getResult().getToken();
+                    setContentView(R.layout.activity_signed_in);
+                    // ...
+                } else {
+                    // Handle error -> task.getException();
+                }
+            }
+        });
+    }
+
     @Override
     public void onStart() {
         super.onStart();

--- a/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/MainActivity.java
@@ -1,20 +1,79 @@
 package ar.uba.fi.mercadolibre;
 
+import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.TextView;
 
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
+import com.firebase.ui.auth.AuthUI;
+import com.google.firebase.auth.GetTokenResult;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
 
     private FirebaseAuth mAuth;
+    private static final int RC_SIGN_IN = 123;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mAuth = FirebaseAuth.getInstance();
-        setContentView(R.layout.activity_main);
+    }
+
+    void setFirebaseLoginActivity() {
+        // Choose authentication providers
+        List<AuthUI.IdpConfig> providers = Arrays.asList(
+                new AuthUI.IdpConfig.EmailBuilder().build(),
+                new AuthUI.IdpConfig.GoogleBuilder().build()
+        );
+        startActivityForResult(
+                AuthUI.getInstance()
+                        .createSignInIntentBuilder()
+                        .setAvailableProviders(providers)
+                        .build(),
+                RC_SIGN_IN);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        // Esto se ejecuta luego del (intento de) sign in del usuario
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RC_SIGN_IN) {
+            // IdpResponse response = IdpResponse.fromResultIntent(data);
+
+            if (resultCode == RESULT_OK) {
+                // Successfully signed in
+                FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+                assert user != null;
+                user.getIdToken(true)
+                        .addOnCompleteListener(new OnCompleteListener<GetTokenResult>() {
+                            public void onComplete(@NonNull Task<GetTokenResult> task) {
+                                if (task.isSuccessful()) {
+                                    String idToken = task.getResult().getToken();
+                                    // Send token to your backend via HTTPS
+                                    // ...
+                                } else {
+                                    // Handle error -> task.getException();
+                                }
+                            }
+                        });                setContentView(R.layout.activity_signed_in);
+
+            } else {
+                // Sign in failed. If response is null the user canceled the
+                // sign-in flow using the back button. Otherwise check
+                // response.getError().getErrorCode() and handle the error.
+                TextView msg = findViewById(R.id.init_view);
+                msg.setText("LOGIN FAILED");
+            }
+        }
     }
     @Override
     public void onStart() {
@@ -23,6 +82,8 @@ public class MainActivity extends AppCompatActivity {
         FirebaseUser currentUser = mAuth.getCurrentUser();
         if (currentUser != null) {
             setContentView(R.layout.activity_signed_in);
+        } else {  // Firebase login view
+            this.setFirebaseLoginActivity();
         }
     }
 }

--- a/app/src/main/java/ar/uba/fi/mercadolibre/server_api/ApiService.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/server_api/ApiService.java
@@ -1,0 +1,11 @@
+package ar.uba.fi.mercadolibre.server_api;
+
+import io.reactivex.Single;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public interface ApiService {
+    final String endpoint = "";
+    @GET("person/{person_id}")
+    Single<ExampleResponse> getExample(@Path("person_id") int personId);
+}

--- a/app/src/main/java/ar/uba/fi/mercadolibre/server_api/AppServer.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/server_api/AppServer.java
@@ -1,0 +1,54 @@
+package ar.uba.fi.mercadolibre.server_api;
+
+import android.util.Log;
+
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+import retrofit2.Retrofit;
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class AppServer {
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
+
+    private String url;
+    public AppServer(String url) {
+        this.url = url;
+    }
+    public void api() {
+        // Actualmente esto siempre falla porque falta una API key, pero funciona,
+        // Se loguea el error en el onError abajo
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(this.url)
+                .addConverterFactory(GsonConverterFactory.create())
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .build();
+
+        ApiService apiService = retrofit.create(ApiService.class);
+        Single<ExampleResponse> response = apiService.getExample(3);
+
+        response.subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(new SingleObserver<ExampleResponse>() {
+                @Override
+                public void onSubscribe(Disposable d) {
+                    compositeDisposable.add(d);
+                }
+
+                @Override
+                public void onSuccess(ExampleResponse person) {
+                    Log.i("Sign up", person.getStatusMessage());
+                }
+                @Override
+                public void onError(Throwable e) {
+                    Log.e("Sign up", e.getLocalizedMessage());
+
+                }
+            });
+    }
+
+}

--- a/app/src/main/java/ar/uba/fi/mercadolibre/server_api/ExampleResponse.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/server_api/ExampleResponse.java
@@ -1,0 +1,31 @@
+package ar.uba.fi.mercadolibre.server_api;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class ExampleResponse {
+
+    @SerializedName("status_code")
+    @Expose
+    private Integer statusCode;
+    @SerializedName("status_message")
+    @Expose
+    private String statusMessage;
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+
+    public void setStatusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     tools:context=".MainActivity">
 
     <TextView
+        android:id="@+id/init_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World!"

--- a/app/src/main/res/layout/activity_signed_in.xml
+++ b/app/src/main/res/layout/activity_signed_in.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -10,6 +10,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/signin_success"
-        tools:layout_editor_absoluteX="139dp"
-        tools:layout_editor_absoluteY="92dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_signed_in.xml
+++ b/app/src/main/res/layout/activity_signed_in.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/login_confirm_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signin_success"
+        tools:layout_editor_absoluteX="139dp"
+        tools:layout_editor_absoluteY="92dp" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">MercadoLibre</string>
+    <string name="signin_success">Success! You logged in!</string>
 </resources>


### PR DESCRIPTION
Closes #3 , Closes #4, Closes #5
Incopora Firebase Auth como servicio para login. Una vez autenticado con las opciones dadas (email + password estándar o Google account), te pasa a una vista de login básico. Una vez autenticado, se puede obtener un token que indica la sesión activa del usuario, que se puede pasar al app-server como credencial de usuario.

También agrega un servicio ejemplo para manejar la API del App server, con un schema trucho (todavía no está definido la estructura de la respuesta del servidor).