### PR TITLE
QR codes generation and reading

### DIFF
--- a/app/src/main/java/ar/uba/fi/mercadolibre/activity/EditArticleActivity.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/activity/EditArticleActivity.java
@@ -11,6 +11,8 @@ import android.support.v4.app.ActivityCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Toast;
@@ -24,6 +26,7 @@ import java.io.IOException;
 
 import ar.uba.fi.mercadolibre.R;
 import ar.uba.fi.mercadolibre.controller.ControllerFactory;
+import ar.uba.fi.mercadolibre.dialogs.ShowQrDialog;
 import ar.uba.fi.mercadolibre.model.Article;
 import ar.uba.fi.mercadolibre.views.ArticleSlider;
 import ar.uba.fi.mercadolibre.views.TagsSpinner;
@@ -44,6 +47,36 @@ public class EditArticleActivity extends BaseActivity {
     @Override
     public int identifierForDrawer() {
         return HOME_IDENTIFIER;
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        if (article.getID() == null) {
+            return false;
+        }
+
+        super.onCreateOptionsMenu(menu);
+        getMenuInflater().inflate(R.menu.menu_edit_article, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.delete:
+                return true;
+
+            case R.id.show_qr:
+                showQr();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    private void showQr() {
+        ShowQrDialog dialog = ShowQrDialog.newInstance(article);
+        dialog.show(getSupportFragmentManager(), "qr");
     }
 
     int[] textFieldIDs = {

--- a/app/src/main/java/ar/uba/fi/mercadolibre/controller/ArticleController.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/controller/ArticleController.java
@@ -17,6 +17,9 @@ public interface ArticleController {
     @GET("article/")
     Call<APIResponse<List<Article>>> list();
 
+    @GET("article/{id}")
+    Call<Article> getByID(@Path("id") String id);
+
     @GET("article/")
     Call<APIResponse<List<Article>>> listByName(@Query("name") String name);
 

--- a/app/src/main/java/ar/uba/fi/mercadolibre/dialogs/ShowQrDialog.java
+++ b/app/src/main/java/ar/uba/fi/mercadolibre/dialogs/ShowQrDialog.java
@@ -1,0 +1,75 @@
+package ar.uba.fi.mercadolibre.dialogs;
+
+import android.app.Dialog;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+
+import ar.uba.fi.mercadolibre.R;
+import ar.uba.fi.mercadolibre.model.Article;
+
+public class ShowQrDialog extends DialogFragment {
+    private Article article = null;
+    private static final String ARTICLE_KEY = "article";
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        article = (Article) getArguments().getSerializable(ARTICLE_KEY);
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage(R.string.qr_code);
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+        View layout = inflater.inflate(R.layout.show_qr, null);
+        fillImage((ImageView) layout.findViewById(R.id.qrImageView));
+
+        builder.setView(layout);
+        return builder.create();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
+
+    private void fillImage(ImageView imageView) {
+
+        QRCodeWriter writer = new QRCodeWriter();
+        try {
+            String content = article.getID();
+            BitMatrix bitMatrix = writer.encode(content, BarcodeFormat.QR_CODE, 512, 512);
+            int width = bitMatrix.getWidth();
+            int height = bitMatrix.getHeight();
+            Bitmap bmp = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565);
+            for (int x = 0; x < width; x++) {
+                for (int y = 0; y < height; y++) {
+                    bmp.setPixel(x, y, bitMatrix.get(x, y) ? Color.BLACK : Color.WHITE);
+                }
+            }
+            imageView.setImageBitmap(bmp);
+
+        } catch (WriterException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static ShowQrDialog newInstance(Article article) {
+        Bundle args = new Bundle();
+        args.putSerializable(ARTICLE_KEY, article);
+        ShowQrDialog fragment = new ShowQrDialog();
+        fragment.setArguments(args);
+        return fragment;
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_more_vert_24px.xml
+++ b/app/src/main/res/drawable/ic_baseline_more_vert_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/layout/show_qr.xml
+++ b/app/src/main/res/layout/show_qr.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal">
+
+    <ImageView
+        android:id="@+id/qrImageView"
+        android:layout_width="250dp"
+        android:layout_height="250dp"
+        android:layout_gravity="center_vertical|center"
+        android:contentDescription="@string/qr_code"
+        android:padding="10dp" />
+</LinearLayout>

--- a/app/src/main/res/menu/menu_edit_article.xml
+++ b/app/src/main/res/menu/menu_edit_article.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".activity.BaseActivity">
+
+    <item
+        android:id="@+id/edit_article_more"
+        android:orderInCategory="100"
+        android:title="@string/more"
+        android:icon="@drawable/ic_baseline_more_vert_24px"
+        app:showAsAction="ifRoom">
+
+        <menu>
+            <item android:id="@+id/show_qr"
+                android:title="@string/show_qr" />
+            <item android:id="@+id/delete"
+                android:title="@string/delete" />
+        </menu>
+    </item>
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,5 +58,8 @@
     <string name="ask_seller">preguntar al vendedor</string>
     <string name="buy">comprar</string>
     <string name="available_units_tag">artículos disponibles</string>
-
+    <string name="scan_qr">Escanear QR</string>
+    <string name="show_qr">Mostrar codigo QR</string>
+    <string name="qr_code">Codigo QR</string>
+    <string name="more">mas opciones</string>
 </resources>


### PR DESCRIPTION
Closes #27 

Adds an option to the Article Edit activity to allow the owner to
generate a QR core for their article. Adds a side panel option to scan
bar codes. When a user scans the article bar code, they'll be redirected
to the article detail activity of the corresponding article.

Modifies some logic in BaseActivity to better generalize actions to
perform after clicking an option in the side panel.